### PR TITLE
db.js file missing .first(); on findById function

### DIFF
--- a/data/db.js
+++ b/data/db.js
@@ -18,7 +18,8 @@ function find() {
 }
 
 function findById(id) {
-  return db('posts').where({ id: Number(id) });
+  return db('posts').where({ id: Number(id) })
+  .first();
 }
 
 function insert(post) {


### PR DESCRIPTION
Updated this function to include .first() not letting 404 happen. 
function findById(id) {
  return db('posts').where({ id: Number(id) })
  .first();
}